### PR TITLE
add chromo mask and export other field line parameters

### DIFF
--- a/pyampp/gx_chromo/combo_model.py
+++ b/pyampp/gx_chromo/combo_model.py
@@ -100,5 +100,6 @@ def combo_model(box, dr, base_bz, base_ic):
         'tr': tr_idx,
         'tr_h': tr_h,
         'corona_base': corona_base_idx,
-        'dr': dr
+        'dr': dr,
+        'chromo_mask': chromo_mask
     }

--- a/pyampp/gxbox/boxutils.py
+++ b/pyampp/gxbox/boxutils.py
@@ -242,6 +242,8 @@ def read_b3d_h5(filename):
             box_b3d[model_type] = {}
             for component in group.keys():
                 box_b3d[model_type][component] = group[component][:]
+            if len(group.attrs.keys()) > 0:
+                box_b3d[model_type]["attrs"] = dict(group.attrs)
     return box_b3d
 
 def write_b3d_h5(filename, box_b3d):
@@ -253,6 +255,7 @@ def write_b3d_h5(filename, box_b3d):
     :param box_b3d: dict,
         A dictionary containing the B3D data to be written.
     """
+
     with h5py.File(filename, 'w') as hdf_file:
         for model_type, components in box_b3d.items():
             if components is None:
@@ -260,4 +263,7 @@ def write_b3d_h5(filename, box_b3d):
                 continue
             group = hdf_file.create_group(model_type)
             for component, data in components.items():
-                group.create_dataset(component, data=data)
+                if component == "attrs":
+                    group.attrs.update(data)
+                else:
+                    group.create_dataset(component, data=data)

--- a/pyampp/gxbox/gxbox_factory.py
+++ b/pyampp/gxbox/gxbox_factory.py
@@ -744,7 +744,6 @@ class GxBox(QMainWindow):
         self.box.b3d['nlfff']['by'] = by_nlff
         self.box.b3d['nlfff']['bz'] = bz_nlff
 
-        ## TODO -------------------
         t1  = time.time()
         print("Calculating field lines")
         lines = maglib.lines(seeds=None)
@@ -769,7 +768,11 @@ class GxBox(QMainWindow):
         chromo_box = combo_model(self.box.b3d['nlfff'], dr3, base_bz.data.T, base_ic.data.T)
         chromo_box["avfield"] = lines["av_field"]
         chromo_box["physlength"] = lines["phys_length"] * dr3[0]
+        chromo_box["apex_idx"] = lines["apex_idx"]
         chromo_box["status"] = lines["voxel_status"]
+        chromo_box["startidx"] = lines["start_idx"]
+        chromo_box["endidx"] = lines["end_idx"]
+        chromo_box["attrs"] = header
         self.box.b3d["chromo"] = chromo_box
         print(f"Time taken to compute chromosphere model: {time.time() - t1:.1f} seconds")
 

--- a/pyampp/gxbox/gxbox_factory.py
+++ b/pyampp/gxbox/gxbox_factory.py
@@ -766,13 +766,12 @@ class GxBox(QMainWindow):
         dr3 = [obs_dr.value, obs_dr.value, obs_dr.value]
 
         chromo_box = combo_model(self.box.b3d['nlfff'], dr3, base_bz.data.T, base_ic.data.T)
-        chromo_box["avfield"] = lines["av_field"]
-        chromo_box["physlength"] = lines["phys_length"] * dr3[0]
-        chromo_box["apex_idx"] = lines["apex_idx"]
-        chromo_box["status"] = lines["voxel_status"]
-        chromo_box["startidx"] = lines["start_idx"]
-        chromo_box["endidx"] = lines["end_idx"]
+        for k in ["codes", "apex_idx", "start_idx", "end_idx", "seed_idx",\
+                  "av_field", "phys_length", "voxel_status"]:
+            chromo_box[k] = lines[k]
+        chromo_box["phys_length"] *= dr3[0]
         chromo_box["attrs"] = header
+
         self.box.b3d["chromo"] = chromo_box
         print(f"Time taken to compute chromosphere model: {time.time() - t1:.1f} seconds")
 


### PR DESCRIPTION
Hey, in order to make CHMP routines for microwave and ultraviolet pipelines (in different software) work, pyAMPP needs to export chromo_mask map and the indices for start and end of traced field lines. Alexey Stupishin's library already provides these parameters, we just _need_ to store them in HDF as well.

This pull request adds some more arrays to the final model object and modifies HDF saving procedure a little bit. Beside arrays, I've added necessary attributes for HDF from FITS header (related to coordinate system). So, please review and merge.